### PR TITLE
Update to 0.5.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.4.0" %}
+{% set version = "0.5.0" %}
 
 package:
   name: folium
@@ -6,10 +6,10 @@ package:
 
 source:
   url: https://pypi.io/packages/source/f/folium/folium-{{ version }}.tar.gz
-  sha256: 8130e1d846ec50bd45758e28135834adbd07474c4d98db3316a5f932eb24cb3b
+  sha256: 748944521146d85c6cd6230acf234e885864cd0f42fea3758d655488517e5e6e
 
 build:
-  number: 1
+  number: 0
   script: python setup.py install --single-version-externally-managed --record record.txt
   noarch: python
 


### PR DESCRIPTION
```
## v0.5.0

- Added `Draw` plugin (ocefpaf #720)
- Better handling of URL input (ocefpaf #717)
- Versioned docs! Visit http://python-visualization.github.io/folium/docs-v0.5.0
  or simply http://python-visualization.github.io/folium/ for the current master version.

### Bug Fixes

- Fix `VideoOverlay` import (ocefpaf #719)
- Fix `choropleth` docstring (lsetiawan #713)
- Fix `choropleth` name in `LayerControl` (ocefpaf #493)
```